### PR TITLE
Upgrade php to 7.1.16 with streatch insead of jessie

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.1.13-fpm
+FROM php:7.1.16-fpm
 
 RUN apt-get update \
   && apt-get install -y \


### PR DESCRIPTION
Changed FROM in Dockerfile to php 7.1.16.
This version is not using jessie repositories - that are not working right now.